### PR TITLE
add 'note' and 'extraFields' to db schema

### DIFF
--- a/sbcatalog/default_settings.py
+++ b/sbcatalog/default_settings.py
@@ -40,6 +40,21 @@ schema = {
         'minlength': 1,
         'maxlength': 20,
     },
+    'note' : {
+        'type': 'string',
+        'minlength': 1,
+        'maxlength': 20,
+    },
+    'extraFields': {
+        'type': 'dict',
+        'schema': {
+            'extraField': {
+                'type': 'string',
+                'minlength': 1,
+                'maxlength': 20,
+            }
+        }
+    },
     'address': {
         'type': 'dict',
         'schema': {


### PR DESCRIPTION
Aggiunti i campi mancanti, a parte `orders` perchè è ancora da decidere se deve far parte o meno di sbcatalog.
